### PR TITLE
CSS content

### DIFF
--- a/templates/profiler/accessibility_collector.html.twig
+++ b/templates/profiler/accessibility_collector.html.twig
@@ -43,6 +43,8 @@
 
         .tab-navigation li, .tab-navigation li * { vertical-align: middle; }
 
+        pre { margin: 0; }
+
         table td, table td * { vertical-align: middle; }
         table ul li { margin: 0; }
         table .small-cell { width: 45px; }
@@ -163,7 +165,8 @@
     <br>
 
     <h3>Alternative text</h3>
-    <p class="text-muted">All images should have an alt attribute. If an image has meaning, you should provide a concise alternative text to describe it. If it's decorative, add the alt attribute and leave it empty. More about <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Img#attributes" target="_blank">the alt attribute</a>.</p>
+    <p class="text-muted">All images must have an alt attribute.</p>
+    <p class="text-muted">If an image has meaning, you should provide a concise alternative text to describe it. If it's decorative, add the alt attribute and leave it empty. More about <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Img#attributes" target="_blank">the alt attribute</a>.</p>
 
     <br>
 
@@ -354,51 +357,48 @@
     #}
 
 
-    <h3>Font Icons</h3>
-    <p class="text-muted">Font icons rely on a font character displayed in CSS with a :before or an :after. Since <strong>CSS displayed text is not accessible to screen readers</strong>, they should be explicitly hidden with the HTML atttribute aria-hidden="true". More about <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-hidden_attribute" target="_blank">the aria-hidden attribute</a>.</p>
-    <div class="metrics">
-        <div class="metric">
-            <span class="value">{{ collector.countAllIcons }}</span>
-            <span class="label">Icons found</span>
-        </div>
-        <div class="metric">
-            <span class="value">{{ collector.countAllExplicitIcons }}</span>
-            <span class="label">visible to screen readers</span>
-        </div>
-    </div>
-    {% if collector.listNonExplicitIcons > 0 %}
-        <div class="card status-info"><strong>These icons are missing the aria-hidden attribute (to hide them from screen readers).</strong></div>
-        <table>
-            <tr>
-                <td>
-                    {{ profiler_dump(collector.seek('listNonExplicitIcons'), maxDepth=1) }}
-                </td>
-            </tr>
-        </table>
-        {#  Todo : is it possible to show every icon in a separate line of the table ? Proposition :
+    <h3>CSS content</h3>
+    <p class="text-muted">CSS displayed content (:before and :after) is not available to screen readers. Make sure it is purely decorative so that assistive technology users can access it.</p>
+    <p class="text-muted">The aria-hidden attribute can expose or hide elements from screen readers. When possible, use this attribute to hide all decorative elements (such as decorative images, icons, offscreen or collapsed content, etc.) from screen readers. More about <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-hidden_attribute" target="_blank">the aria-hidden attribute</a>.</p>
 
-            <table>
-                <thead>
-                    <th>#</th>
-                    <th>Icon class</th>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td class="font-normal text-muted nowrap small-cell">1</td>
-                        <td>icon icon--bell</td>
-                    </tr>
-                    <tr>
-                        <td class="font-normal text-muted nowrap small-cell">1</td>
-                        <td>icon icon--menu</td>
-                    </tr>
-                </tbody>
-            </table>
-        #}
-    {% else %}
-        <div class="empty">
-            <p>No icons found on this page.</p>
-        </div>
-    {% endif %}
+    <table>
+        <thead>
+        <tr>
+            <th>#</th>
+            <th>Tag</th>
+            <th>Aria hidden</th>
+        </tr>
+        </thead>
+        <tbody>
+             <tr>
+                <td class="font-normal text-muted nowrap small-cell">1</td>
+                <td>
+<pre><code>&lt;i class="fa fa-bell" aria-hidden="true"&gt;
+  :before
+&lt;/i&gt;</code></pre>
+                </td>
+                <td>true</td>
+            </tr>
+            <tr>
+                <td class="font-normal text-muted nowrap small-cell">2</td>
+                <td>
+<pre><code>&lt;i class="fa fa-bell" aria-hidden="false"&gt;
+  :before
+&lt;/i&gt;</code></pre>
+                </td>
+                <td>false</td>
+            </tr>
+            <tr>
+                <td class="font-normal text-muted nowrap small-cell">3</td>
+                <td>
+<pre><code>&lt;i class="fa fa-bell"&gt;
+  :before
+&lt;/i&gt;</code></pre>
+                </td>
+                <td>false</td>
+            </tr>
+        </tbody>
+    </table>
 
     <br>
 

--- a/templates/profiler/accessibility_collector.html.twig
+++ b/templates/profiler/accessibility_collector.html.twig
@@ -1,6 +1,40 @@
 {% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
+    <style>
+        .section-andi {
+            margin-top: 25px;
+            display: flex;
+            justify-content: center;
+        }
+
+        .section-andi .button {
+            margin: 0 0 10px;
+            padding: 10px 25px;
+            display: flex;
+            justify-content: center;
+            font-size: 14px;
+            color: #fff !important;
+            text-decoration: none !important;
+            background: #666;
+        }
+
+        .section-andi a {
+            color: rgba(255, 255, 255, .8) !important;
+            display: flex;
+            justify-content: center;
+            text-decoration: underline !important;
+            border: none;
+            transition: color ease-in .15s;
+        }
+
+        .section-andi a:hover,
+        .section-andi a:active,
+        .section-andi a:focus {
+            color: rgba(255, 255, 255, 1) !important;
+        }
+    </style>
+
     {% set icon %}
         {# this is the content displayed as a panel in the toolbar #}
         {{ include('@ElaoAccesseo/profiler/179-accessibility.svg.twig') }}
@@ -12,18 +46,20 @@
            the toolbar panel #}
         <div class="sf-toolbar-info-piece">
             <b>Images with alt attribute / Total images :</b>
-            <span>{{ collector.countAltFromImages }} / {{ collector.countAllImages }} </span>
+            <span class="sf-toolbar-status">{{ collector.countAltFromImages }} / {{ collector.countAllImages }}</span>
         </div>
         <div class="sf-toolbar-info-piece">
-            <b>Explicit icons / Total icons:</b>
-            <span>{{ collector.countAllExplicitIcons }} / {{ collector.countAllIcons }}</span>
+            <b>CSS content</b>
+            <span>none</span> {# detected / none #}
         </div>
         <div class="sf-toolbar-info-piece">
             <b>Total buttons without text:</b>
-            <span>{{ collector.countMissingTextInButtons }}</span>
+            <span class="sf-toolbar-status">{{ collector.countMissingTextInButtons }}</span>
         </div>
-        <div class="sf-toolbar-info-piece">
-            <b>Launch <a href="javascript:void((function(){andiScript=document.createElement('script');andiScript.setAttribute('src','https://www.ssa.gov/accessibility/andi/andi.js');document.body.appendChild(andiScript)})());">ANDI</a> on this page, <a href="https://www.ssa.gov/accessibility/andi/help/install.html">(accessibility testing tool).</a></b>
+        <div class="section-andi">
+            <div class="sf-toolbar-info-piece">
+                <a href="javascript:void((function(){andiScript=document.createElement('script');andiScript.setAttribute('src','https://www.ssa.gov/accessibility/andi/andi.js');document.body.appendChild(andiScript)})());" class="button">Launch ANDI</a> <a href="https://www.ssa.gov/accessibility/andi/help/install.html">What is ANDI ?</a>
+            </div>
         </div>
     {% endset %}
 


### PR DESCRIPTION
target all :before and :after pseudo elements rather than just icons with their css classes

Issue : https://github.com/Elao/accesseo/issues/60

<img width="1081" alt="Capture d’écran 2021-08-19 à 15 21 57" src="https://user-images.githubusercontent.com/25897625/130083312-0f949ff3-7cf8-4c97-97f0-63f24b949739.png">
